### PR TITLE
Исправлена проверка кода возврата в autotest/test.sh

### DIFF
--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -26,10 +26,11 @@ run_test_aux() {
   fi
 
   ./$EXE 2> __dump.txt
-  if [ $? -ge 200 ]; then
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -ge 200 ]; then
     echo TEST FAILED, SEE __dump.txt
     exit
-  elif [ $? -ge 0 ]; then
+  elif [ $EXIT_CODE -ne 0 ]; then
     echo "TEST FAILED (INTERNAL ERROR)"
     exit
   fi


### PR DESCRIPTION
Код возврата это значение от 0-255, получается, ветка elif всегда выполнялась.

К тому же, вызов `[ $? -ge 200 ];` в первой ветке переписывал код возврата, так как `[]` - это вызов команды, поэтому ветка elif по-факту не проверяла код возврата исходной команды