### PR TITLE
Исправление autotest/run.sh

### DIFF
--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -77,6 +77,8 @@ run_test_aux.BAD-SYNTAX() {
 }
 
 run_test_aux.SATELLITE() {
+  # echo нужен, так как bash не позволяет объявлять пустые функции
+  echo "Skip run_test_aux.SATELLITE"
 }
 
 run_test() {

--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -28,7 +28,7 @@ run_test_aux() {
       exit
     fi
   else
-    set SATELLITEC=
+    SATELLITEC=
   fi
 
   $CLINE -I../lib -o$EXE $CFILE $SATELLITEC ../lib/Library.c ../lib/refal05rts.c


### PR DESCRIPTION
Для сброса переменной SATELLITEC было использовано некорректное выражение`set SATELLITEC=` (такая конструкция по-факту просто переписывала $1 значением "SATELLITEC=")

Это приводило к следующей ошибке при запуске автотестов:
```
>> ./bootstrap.sh 
...
Passing arithmetic-32-bit.ref...
*Compiling arithmetic-32-bit.ref:
*** Compilation successed ***
cc1: fatal error: arithmetic-32-bit.SATELLITE.c: No such file or directory
compilation terminated.
COMPILATION FAILED
```

Помимо этого, функция run_test_aux.SATELLITE была пустой, что является невалидным синтаксисом для bash
