### PR TITLE
 <?...> ошибочно помечается как Extern

### DIFF
--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -77,6 +77,8 @@ run_test_aux.BAD-SYNTAX() {
 }
 
 run_test_aux.SATELLITE() {
+  # echo нужен, так как bash не позволяет объявлять пустые функции
+  echo "Skip run_test_aux.SATELLITE"
 }
 
 run_test() {

--- a/autotests/run.sh
+++ b/autotests/run.sh
@@ -28,7 +28,7 @@ run_test_aux() {
       exit
     fi
   else
-    set SATELLITEC=
+    SATELLITEC=
   fi
 
   $CLINE -I../lib -o$EXE $CFILE $SATELLITEC ../lib/Library.c ../lib/refal05rts.c

--- a/src/R05-Parser.ref
+++ b/src/R05-Parser.ref
@@ -112,8 +112,14 @@ FindUnused-Loop {
         t.ErrorList <AddMetatable (e.References) e.AST>
       >;
 
+  t.ErrorList ((s.How s.MetaSugarName) e.References) e.AST
+    , '?' : e.1 s.MetaSugarName e.2
+    = <FindUnused-Loop
+        t.ErrorList <AddMetatable (e.References) e.AST>
+      >;
+
   t.ErrorList ((s.How s.SugarName) e.References) e.AST
-    , '%*+-/?' : e.1 s.SugarName e.2
+    , '%*+-/' : e.1 s.SugarName e.2
     = <FindUnused-Loop
         t.ErrorList (e.References)
         e.AST (Function Used NO-POS (s.SugarName) Extern /* пусто */)


### PR DESCRIPTION
Вызов `<?...>` обрабатывается в `FindUnused-Loop`  так же, как и другие алиасы, из-за чего к нему приписывается ненужный Extern, что приводит к дублирующему объявлению и ошибке компиляции

Эта ошибка отлавливается автотестом `mu.ref`:
```
./lib/refal05rts.h:309:30: error: static declaration of ‘r05f_k3F_’ follows non-static declaration
  309 |   static struct r05_function r05f_ ## name = { \
      |                              ^~~~~
mu.c:28:1: note: in expansion of macro ‘R05_DEFINE_METAFUNCTION’
   28 | R05_DEFINE_METAFUNCTION(k3F_, "?")
      | ^~~~~~~~~~~~~~~~~~~~~~~
../lib/refal05rts.h:276:30: note: previous declaration of ‘r05f_k3F_’ with type ‘struct r05_function’
  276 |   extern struct r05_function r05f_ ## name;
      |                              ^~~~~
mu.c:21:1: note: in expansion of macro ‘R05_DECLARE_ENTRY_FUNCTION’
   21 | R05_DECLARE_ENTRY_FUNCTION(k3F_)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
COMPILATION FAILED
````

> этот PR сделан поверх #43, чтобы была возможность запустить автотесты. После мержа #43 гитхаб должен скрыть лишние коммиты